### PR TITLE
Add 'intllib' as optional dependency

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -1,1 +1,2 @@
 default
+intllib?


### PR DESCRIPTION
***intllib*** is missing from ***depends.txt***.